### PR TITLE
Fix enable_extension rollback in timescaledb schema dumper.

### DIFF
--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -18,7 +18,9 @@ module Timescaledb
     end
 
     def views(stream)
-      timescale_continuous_aggregates(stream) if Timescaledb::ContinuousAggregates.table_exists? # Define these before any Scenic views that might use them
+      return unless Timescaledb::ContinuousAggregates.table_exists?
+
+      timescale_continuous_aggregates(stream) # Define these before any Scenic views that might use them
       super if defined?(super)
     end
 

--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -10,7 +10,8 @@ module Timescaledb
 
     def table(table_name, stream)
       super(table_name, stream)
-      if hypertable = Timescaledb::Hypertable.find_by(hypertable_name: table_name)
+      if Timescaledb::Hypertable.table_exists? &&
+         (hypertable = Timescaledb::Hypertable.find_by(hypertable_name: table_name))
         timescale_hypertable(hypertable, stream)
         timescale_retention_policy(hypertable, stream)
       end

--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -18,7 +18,7 @@ module Timescaledb
     end
 
     def views(stream)
-      timescale_continuous_aggregates(stream) # Define these before any Scenic views that might use them
+      timescale_continuous_aggregates(stream) if Timescaledb::ContinuousAggregates.table_exists? # Define these before any Scenic views that might use them
       super if defined?(super)
     end
 


### PR DESCRIPTION
See issue #15 about the description of this PR.