### PR TITLE
Use the first dimension when creating hypertable

### DIFF
--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -27,7 +27,7 @@ module Timescaledb
     private
 
     def timescale_hypertable(hypertable, stream)
-      dim = hypertable.dimensions
+      dim = hypertable.dimensions.first
       extra_settings = {
         time_column: "#{dim.column_name}",
         chunk_time_interval: "#{dim.time_interval.inspect}"


### PR DESCRIPTION
`hypertable.dimensions` returns an instance of `ActiveRecord::Associations::CollectionProxy`, but it looks like we were expecting it to be just a single `Timescale::Dimension` instance. This causes the `timescale_hypertable` method to fail.

Using `hypertable.dimensions.first` allows `timescale_hypertable` to function correctly; it's possible that we'd want to process the additional dimensions and output `add_dimension` commands to the `schema.rb` file too, but I haven't tackled that here.

Fixes #29.