### PR TITLE
Dump hypertables and retention policies last, for compatibility with foreign keys

### DIFF
--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -7,6 +7,8 @@ module Timescaledb
       super # This will call #table for each table in the database
       views(stream) unless defined?(Scenic) # Don't call this twice if we're using Scenic
 
+      return unless Timescaledb::Hypertable.table_exists?
+
       timescale_hypertables(stream)
       timescale_retention_policies(stream)
     end

--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -6,14 +6,16 @@ module Timescaledb
     def tables(stream)
       super # This will call #table for each table in the database
       views(stream) unless defined?(Scenic) # Don't call this twice if we're using Scenic
+      timescale_hypertables(stream)
+      timescale_retention_policies(stream)
     end
 
     def table(table_name, stream)
       super(table_name, stream)
       if Timescaledb::Hypertable.table_exists? &&
          (hypertable = Timescaledb::Hypertable.find_by(hypertable_name: table_name))
-        timescale_hypertable(hypertable, stream)
-        timescale_retention_policy(hypertable, stream)
+        timescale_hypertable(hypertable, @hypertables)
+        timescale_retention_policy(hypertable, @retention_policies)
       end
     end
 
@@ -22,6 +24,14 @@ module Timescaledb
 
       timescale_continuous_aggregates(stream) # Define these before any Scenic views that might use them
       super if defined?(super)
+    end
+
+    def timescale_hypertables(stream)
+      stream.puts(@hypertables)
+    end
+
+    def timescale_retention_policies(stream)
+      stream.puts(@retention_policies)
     end
 
     private

--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -23,11 +23,8 @@ module Timescaledb
     def timescale_hypertables(stream)
       stream.puts # Insert a blank line above the retention policies, for readability
 
-      @connection.tables.sort.each do |table_name|
-        if Timescaledb::Hypertable.table_exists? &&
-          (hypertable = Timescaledb::Hypertable.find_by(hypertable_name: table_name))
-          timescale_hypertable(hypertable, stream)
-        end
+      Timescaledb::Hypertable.find_each do |hypertable|
+         timescale_hypertable(hypertable, stream)
       end
     end
 

--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -31,11 +31,8 @@ module Timescaledb
     def timescale_retention_policies(stream)
       stream.puts # Insert a blank line above the retention policies, for readability
 
-      @connection.tables.sort.each do |table_name|
-        if Timescaledb::Hypertable.table_exists? &&
-          (hypertable = Timescaledb::Hypertable.find_by(hypertable_name: table_name))
-          timescale_retention_policy(hypertable, stream)
-        end
+      Timescaledb::Hypertable.find_each do |hypertable|
+        timescale_retention_policy(hypertable, stream)
       end
     end
 

--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -21,7 +21,7 @@ module Timescaledb
     end
 
     def timescale_hypertables(stream)
-      stream.puts # Insert a blank line above the retention policies, for readability
+      stream.puts # Insert a blank line above the hypertable definitions, for readability
 
       Timescaledb::Hypertable.find_each do |hypertable|
          timescale_hypertable(hypertable, stream)


### PR DESCRIPTION
TimescaleDB doesn't allow us to add new foreign keys to compressed hypertables, so we need to make sure that the foreign keys have been added _before_ enabling compression.

The same is also true of retention policies.

Fixes #33.