### PR TITLE
Add support for optional hypertable arguments

### DIFF
--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -21,15 +21,15 @@ module Timescaledb
     end
 
     def timescale_hypertables(stream)
-      stream.puts # Insert a blank line above the hypertable definitions, for readability
-
       sorted_hypertables.each do |hypertable|
         timescale_hypertable(hypertable, stream)
       end
     end
 
     def timescale_retention_policies(stream)
-      stream.puts # Insert a blank line above the retention policies, for readability
+      if sorted_hypertables.any? { |hypertable| hypertable.jobs.exists?(proc_name: "policy_retention") }
+        stream.puts # Insert a blank line above the retention policies, for readability
+      end
 
       sorted_hypertables.each do |hypertable|
         timescale_retention_policy(hypertable, stream)


### PR DESCRIPTION
The current hypertable options only allow for a small subset of the arguments supported by the plugin. It's relatively straightforward to add generic support for _any_ hypertable options to be passed through.

As part of this effort, I've improved the SchemaDumper to handle the majority of persistent options that impact the final database schema.