### PR TITLE
update base class for timescale models

### DIFF
--- a/lib/timescaledb.rb
+++ b/lib/timescaledb.rb
@@ -1,5 +1,6 @@
 require 'active_record'
 
+require_relative 'timescaledb/application_record'
 require_relative 'timescaledb/acts_as_hypertable'
 require_relative 'timescaledb/acts_as_hypertable/core'
 require_relative 'timescaledb/toolkit'

--- a/lib/timescaledb/application_record.rb
+++ b/lib/timescaledb/application_record.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Timescaledb
+  class ApplicationRecord < ::ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/lib/timescaledb/chunk.rb
+++ b/lib/timescaledb/chunk.rb
@@ -1,5 +1,5 @@
 module Timescaledb
-  class Chunk < ActiveRecord::Base
+  class Chunk < ::Timescaledb::ApplicationRecord
     self.table_name = "timescaledb_information.chunks"
     self.primary_key = "chunk_name"
 

--- a/lib/timescaledb/compression_settings.rb
+++ b/lib/timescaledb/compression_settings.rb
@@ -1,5 +1,5 @@
 module Timescaledb
-  class CompressionSetting < ActiveRecord::Base
+  class CompressionSetting < ::Timescaledb::ApplicationRecord
     self.table_name = "timescaledb_information.compression_settings"
     belongs_to :hypertable, foreign_key: :hypertable_name
   end

--- a/lib/timescaledb/continuous_aggregates.rb
+++ b/lib/timescaledb/continuous_aggregates.rb
@@ -1,5 +1,5 @@
 module Timescaledb
-  class ContinuousAggregate < ActiveRecord::Base
+  class ContinuousAggregate < ::Timescaledb::ApplicationRecord
     self.table_name = "timescaledb_information.continuous_aggregates"
     self.primary_key = 'materialization_hypertable_name'
 

--- a/lib/timescaledb/dimensions.rb
+++ b/lib/timescaledb/dimensions.rb
@@ -1,5 +1,5 @@
 module Timescaledb
-  class Dimension < ActiveRecord::Base
+  class Dimension < ::Timescaledb::ApplicationRecord
     self.table_name = "timescaledb_information.dimensions"
 #    attribute :time_interval, :interval
   end

--- a/lib/timescaledb/hypertable.rb
+++ b/lib/timescaledb/hypertable.rb
@@ -1,5 +1,5 @@
 module Timescaledb
-  class Hypertable < ActiveRecord::Base
+  class Hypertable < ::Timescaledb::ApplicationRecord
     self.table_name = "timescaledb_information.hypertables"
     self.primary_key = "hypertable_name"
 

--- a/lib/timescaledb/job.rb
+++ b/lib/timescaledb/job.rb
@@ -1,5 +1,5 @@
 module Timescaledb
-  class Job < ActiveRecord::Base
+  class Job < ::Timescaledb::ApplicationRecord
     self.table_name = "timescaledb_information.jobs"
     self.primary_key = "job_id"
 

--- a/lib/timescaledb/job_stats.rb
+++ b/lib/timescaledb/job_stats.rb
@@ -1,5 +1,5 @@
 module Timescaledb
-  class JobStat < ActiveRecord::Base
+  class JobStat < ::Timescaledb::ApplicationRecord
     self.table_name = "timescaledb_information.job_stats"
 
     belongs_to :job


### PR DESCRIPTION
closes #32 

this PR adds more flexibility for multi database cases. for example, it will be possible to switch all timescale models to other database with just a single line:
```ruby
Timescaledb::ApplicationRecord.connects_to(database: { writing: :reports, reading: :reports })
```

or easily switch between databases/shards using any other method described in https://guides.rubyonrails.org/active_record_multiple_databases.html