### PR TITLE
shrink gem size

### DIFF
--- a/timescaledb.gemspec
+++ b/timescaledb.gemspec
@@ -20,11 +20,9 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files         = Dir["lib/**/*", "LICENSE.txt"]
   spec.bindir        = "bin"
-  spec.executables   = spec.files.grep(%r{^bin/tsdb}) { |f| File.basename(f) }
+  spec.executables   = ["tsdb"]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "pg", "~> 1.2"


### PR DESCRIPTION
currently this gem comes bundled with a bunch of unnecessary files
```
$ tree -aL 1
.
├── .github
├── .gitignore
├── .rspec
├── .ruby-version
├── .tool-versions
├── .travis.yml
├── CODE_OF_CONDUCT.md
├── Fastfile
├── Gemfile
├── Gemfile.lock
├── Gemfile.scenic
├── Gemfile.scenic.lock
├── LICENSE.txt
├── README.md
├── Rakefile
├── bin
├── docs
├── examples
├── lib
├── mkdocs.yml
└── timescaledb.gemspec
```

also it's size is slightly more than 8 MB mostly because of the `docs/` directory
```
$ du -hs timescaledb-0.2.6.gem
8.0M    timescaledb-0.2.6.gem
```

after removing those extra files it'll be only 16 KB
```
$ du -hs timescaledb-0.2.6.gem 
16K     timescaledb-0.2.6.gem
```

I didn't include the `README.md` because it has references to the `examples/` directory which is not included in the gem, but feel free to add it if you think that it's necessary