### PR TITLE
Add continuous aggregate SQL functions

### DIFF
--- a/lib/timescaledb/database/schema_statements.rb
+++ b/lib/timescaledb/database/schema_statements.rb
@@ -15,7 +15,7 @@ module Timescaledb
 
         arguments  = [quote(relation), quote(time_column_name)]
         arguments += [quote(partitioning_column), number_partitions] if partitioning_column && number_partitions
-        arguments += cast_create_hypertable_optional_arguments(options)
+        arguments += create_hypertable_options_to_named_notation_sql(options)
 
         "SELECT create_hypertable(#{arguments.join(', ')});"
       end
@@ -56,7 +56,7 @@ module Timescaledb
         options.transform_keys!(&:to_sym)
 
         arguments = [quote(hypertable), interval_to_sql(compress_after)]
-        arguments += cast_policy_optional_arguments(options)
+        arguments += policy_options_to_named_notation_sql(options)
 
         "SELECT add_compression_policy(#{arguments.join(', ')});"
       end
@@ -70,7 +70,7 @@ module Timescaledb
         options.transform_keys!(&:to_sym)
 
         arguments = [quote(hypertable)]
-        arguments += cast_policy_optional_arguments(options)
+        arguments += policy_options_to_named_notation_sql(options)
 
         "SELECT remove_compression_policy(#{arguments.join(', ')});"
       end
@@ -85,7 +85,7 @@ module Timescaledb
         options.transform_keys!(&:to_sym)
 
         arguments = [quote(hypertable), interval_to_sql(drop_after)]
-        arguments += cast_policy_optional_arguments(options)
+        arguments += policy_options_to_named_notation_sql(options)
 
         "SELECT add_retention_policy(#{arguments.join(', ')});"
       end
@@ -99,7 +99,7 @@ module Timescaledb
         options.transform_keys!(&:to_sym)
 
         arguments = [quote(hypertable)]
-        arguments += cast_policy_optional_arguments(options)
+        arguments += policy_options_to_named_notation_sql(options)
 
         "SELECT remove_retention_policy(#{arguments.join(', ')});"
       end
@@ -114,7 +114,7 @@ module Timescaledb
         options.transform_keys!(&:to_sym)
 
         arguments = [quote(hypertable), quote(index_name)]
-        arguments += cast_policy_optional_arguments(options)
+        arguments += policy_options_to_named_notation_sql(options)
 
         "SELECT add_reorder_policy(#{arguments.join(', ')});"
       end
@@ -128,40 +128,120 @@ module Timescaledb
         options.transform_keys!(&:to_sym)
 
         arguments = [quote(hypertable)]
-        arguments += cast_policy_optional_arguments(options)
+        arguments += policy_options_to_named_notation_sql(options)
 
         "SELECT remove_reorder_policy(#{arguments.join(', ')});"
+      end
+
+      # @see https://docs.timescale.com/api/latest/continuous-aggregates/create_materialized_view
+      #
+      # @param [String] continuous_aggregate The name of the continuous aggregate view to be created
+      # @param [Hash] options The optional arguments
+      # @return [String] The create materialized view SQL statement
+      def create_continuous_aggregate_sql(continuous_aggregate, sql, **options)
+        options.transform_keys!(&:to_sym)
+
+        with_data_opts = %w[WITH DATA]
+        with_data_opts.insert(1, 'NO') if options.key?(:with_no_data)
+
+        <<~SQL
+          CREATE MATERIALIZED VIEW #{continuous_aggregate}
+          WITH (timescaledb.continuous) AS
+          #{sql.strip}
+          #{with_data_opts.join(' ')};
+        SQL
+      end
+
+      # @see https://docs.timescale.com/api/latest/continuous-aggregates/drop_materialized_view
+      #
+      # @param [String] continuous_aggregate The name of the continuous aggregate view to be dropped
+      # @param [Boolean] cascade A boolean to drop objects that depend on the continuous aggregate view
+      # @return [String] The drop materialized view SQL statement
+      def drop_continuous_aggregate_sql(continuous_aggregate, cascade: false)
+        arguments = [continuous_aggregate]
+        arguments << 'CASCADE' if cascade
+
+        "DROP MATERIALIZED VIEW #{arguments.join(' ')};"
+      end
+
+      # @see https://docs.timescale.com/api/latest/continuous-aggregates/add_continuous_aggregate_policy
+      #
+      # @param [String] continuous_aggregate The name of the continuous aggregate to add the policy for
+      # @param [String] start_offset The start of the refresh window as an interval relative to the time when the policy is executed
+      # @param [String] end_offset The end of the refresh window as an interval relative to the time when the policy is executed
+      # @param [String] schedule_interval The interval between refresh executions in wall-clock time
+      # @param [Hash] options The optional arguments
+      # @return [String] The add_continuous_aggregate_policy SQL statement
+      def add_continuous_aggregate_policy_sql(continuous_aggregate, start_offset: nil, end_offset: nil, schedule_interval:, **options)
+        options.transform_keys!(&:to_sym)
+
+        arguments = [quote(continuous_aggregate)]
+        arguments << named_notation_sql(name: :start_offset, value: interval_to_sql(start_offset))
+        arguments << named_notation_sql(name: :end_offset, value: interval_to_sql(end_offset))
+        arguments << named_notation_sql(name: :schedule_interval, value: interval_to_sql(schedule_interval))
+        arguments += continuous_aggregate_policy_options_to_named_notation_sql(options)
+
+        "SELECT add_continuous_aggregate_policy(#{arguments.join(', ')});"
+      end
+
+      # @see https://docs.timescale.com/api/latest/continuous-aggregates/remove_continuous_aggregate_policy
+      #
+      # @param [String] continuous_aggregate The name of the continuous aggregate the policy should be removed from
+      # @param [Hash] options The optional arguments
+      # @return [String] The remove_continuous_aggregate_policy SQL statement
+      def remove_continuous_aggregate_policy_sql(continuous_aggregate, **options)
+        options.transform_keys!(&:to_sym)
+
+        arguments = [quote(continuous_aggregate)]
+        arguments += policy_options_to_named_notation_sql(options)
+
+        "SELECT remove_continuous_aggregate_policy(#{arguments.join(', ')});"
       end
 
       private
 
       # @param [Array<Hash<Symbol, Object>>] options The policy optional arguments.
       # @return [Array<String>]
-      def cast_policy_optional_arguments(options)
+      def policy_options_to_named_notation_sql(options)
         options.map do |option, value|
           case option
-          when :if_not_exists, :if_exists then "#{option} => #{boolean_to_sql(value)}"
-          when :initial_start, :timezone then "#{option} => #{quote(value)}"
+          when :if_not_exists, :if_exists then named_notation_sql(name: option, value: boolean_to_sql(value))
+          when :initial_start, :timezone then named_notation_sql(name: option, value: quote(value))
           end
         end.compact
       end
 
       # @param [Array<Hash<Symbol, Object>>] options The create_hypertable optional arguments.
       # @return [Array<String>]
-      def cast_create_hypertable_optional_arguments(options)
+      def create_hypertable_options_to_named_notation_sql(options)
         options.map do |option, value|
           case option
           when :chunk_time_interval
-            "#{option} => #{interval_to_sql(value)}"
+            named_notation_sql(name: option, value: interval_to_sql(value))
           when :if_not_exists, :create_default_indexes, :migrate_data, :distributed
-            "#{option} => #{boolean_to_sql(value)}"
+            named_notation_sql(name: option, value: boolean_to_sql(value))
           when :partitioning_func, :associated_schema_name,
                :associated_table_prefix, :time_partitioning_func
-            "#{option} => #{quote(value)}"
+            named_notation_sql(name: option, value: quote(value))
           when :replication_factor
-            "#{option} => #{value}"
+            named_notation_sql(name: option, value: value)
           end
         end.compact
+      end
+
+      # @param [Array<Hash<Symbol, Object>>] options The continuous aggregate policy arguments.
+      # @return [Array<String>]
+      def continuous_aggregate_policy_options_to_named_notation_sql(options)
+        options.map do |option, value|
+          case option
+          when :if_not_exists then named_notation_sql(name: option, value: boolean_to_sql(value))
+          when :initial_start, :timezone then named_notation_sql(name: option, value: quote(value))
+          end
+        end.compact
+      end
+
+      def named_notation_sql(name:, value:)
+        "#{name} => #{value}"
       end
     end
   end

--- a/lib/timescaledb/database/types.rb
+++ b/lib/timescaledb/database/types.rb
@@ -1,9 +1,12 @@
 module Timescaledb
   class Database
     module Types
-      # @param [String] interval The interval value
+      # @param [String, Integer] interval The interval value
       # @return [String]
       def interval_to_sql(interval)
+        return 'NULL' if interval.nil?
+        return interval if interval.kind_of?(Integer)
+
         "INTERVAL #{quote(interval)}"
       end
 

--- a/spec/timescaledb/database/types_spec.rb
+++ b/spec/timescaledb/database/types_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'timescaledb/database'
+
+RSpec.describe Timescaledb::Database do
+  describe '.interval_to_sql' do
+    context 'when passing nil' do
+      it 'returns NULL' do
+        expect(described_class.interval_to_sql(nil)).to eq('NULL')
+      end
+    end
+
+    context 'when passing an integer' do
+      it 'returns raw integer value' do
+        expect(described_class.interval_to_sql(60*60*24)).to eq(86400)
+      end
+    end
+
+    context 'when passing a string' do
+      it 'returns the interval SQL statement' do
+        expect(described_class.interval_to_sql('1 day')).to eq("INTERVAL '1 day'")
+      end
+    end
+  end
+
+  describe '.boolean_to_sql' do
+    context 'when passing true' do
+      it 'returns expected SQL value' do
+        expect(described_class.boolean_to_sql(true)).to eq("'TRUE'")
+      end
+    end
+
+    context 'when passing false' do
+      it 'returns expected SQL value' do
+        expect(described_class.boolean_to_sql(false)).to eq("'FALSE'")
+      end
+    end
+
+    context 'when passing nil' do
+      it 'returns expected SQL value' do
+        expect(described_class.boolean_to_sql(nil)).to eq("'FALSE'")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduces continuous aggregate functions to Timescaledb::Database
  * create_continuous_aggregate_sql
  * drop_continuous_aggregate_sql
  * add_continuous_aggregate_policy_sql
  * remove_continuous_aggregate_policy_sql