### PR TITLE
Add hypertable and chunk SQL functions

### DIFF
--- a/lib/timescaledb/database.rb
+++ b/lib/timescaledb/database.rb
@@ -1,9 +1,13 @@
+require_relative 'database/chunk_statements'
+require_relative 'database/hypertable_statements'
 require_relative 'database/quoting'
 require_relative 'database/schema_statements'
 require_relative 'database/types'
 
 module Timescaledb
   class Database
+    extend ChunkStatements
+    extend HypertableStatements
     extend Quoting
     extend SchemaStatements
     extend Types

--- a/lib/timescaledb/database/chunk_statements.rb
+++ b/lib/timescaledb/database/chunk_statements.rb
@@ -1,0 +1,21 @@
+module Timescaledb
+  class Database
+    module ChunkStatements
+      # @see https://docs.timescale.com/api/latest/compression/compress_chunk/
+      #
+      # @param [String] chunk_name The name of the chunk to be compressed
+      # @return [String] The compress_chunk SQL statement
+      def compress_chunk_sql(chunk_name)
+        "SELECT compress_chunk(#{quote(chunk_name)});"
+      end
+
+      # @see https://docs.timescale.com/api/latest/compression/decompress_chunk/
+      #
+      # @param [String] chunk_name The name of the chunk to be decompressed
+      # @return [String] The decompress_chunk SQL statement
+      def decompress_chunk_sql(chunk_name)
+        "SELECT decompress_chunk(#{quote(chunk_name)});"
+      end
+    end
+  end
+end

--- a/lib/timescaledb/database/hypertable_statements.rb
+++ b/lib/timescaledb/database/hypertable_statements.rb
@@ -1,0 +1,37 @@
+module Timescaledb
+  class Database
+    module HypertableStatements
+      # @see https://docs.timescale.com/api/latest/hypertable/hypertable_size/
+      #
+      # @param [String] hypertable The hypertable to show size of
+      # @return [String] The hypertable_size SQL statement
+      def hypertable_size_sql(hypertable)
+        "SELECT hypertable_size(#{quote(hypertable)});"
+      end
+
+      # @see https://docs.timescale.com/api/latest/hypertable/hypertable_detailed_size/
+      #
+      # @param [String] hypertable The hypertable to show detailed size of
+      # @return [String] The hypertable_detailed_size SQL statementh
+      def hypertable_detailed_size_sql(hypertable)
+        "SELECT * FROM hypertable_detailed_size(#{quote(hypertable)});"
+      end
+
+      # @see https://docs.timescale.com/api/latest/hypertable/hypertable_index_size/
+      #
+      # @param [String] index_name The name of the index on a hypertable
+      # @return [String] The hypertable_detailed_size SQL statementh
+      def hypertable_index_size_sql(index_name)
+        "SELECT hypertable_index_size(#{quote(index_name)});"
+      end
+
+      # @see https://docs.timescale.com/api/latest/hypertable/chunks_detailed_size/
+      #
+      # @param [String] hypertable The name of the hypertable
+      # @return [String] The chunks_detailed_size SQL statementh
+      def chunks_detailed_size_sql(hypertable)
+        "SELECT * FROM chunks_detailed_size(#{quote(hypertable)});"
+      end
+    end
+  end
+end

--- a/spec/timescaledb/database/chunk_statements_spec.rb
+++ b/spec/timescaledb/database/chunk_statements_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'timescaledb/database'
+
+RSpec.describe Timescaledb::Database do
+  describe '.compress_chunk_sql' do
+    it 'returns expected SQL' do
+      expect(
+        described_class.compress_chunk_sql('_timescaledb_internal._hyper_1_2_chunk')
+      ).to eq("SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');")
+    end
+  end
+
+  describe '.decompress_chunk_sql' do
+    it 'returns expected SQL' do
+      expect(
+        described_class.decompress_chunk_sql('_timescaledb_internal._hyper_1_2_chunk')
+      ).to eq("SELECT decompress_chunk('_timescaledb_internal._hyper_1_2_chunk');")
+    end
+  end
+end

--- a/spec/timescaledb/database/hypertable_statements_spec.rb
+++ b/spec/timescaledb/database/hypertable_statements_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'timescaledb/database'
+
+RSpec.describe Timescaledb::Database do
+  describe '.hypertable_size_sql' do
+    it 'returns expected SQL' do
+      expect(
+        described_class.hypertable_size_sql('events')
+      ).to eq("SELECT hypertable_size('events');")
+    end
+  end
+
+  describe '.hypertable_detailed_size_sql' do
+    it 'returns expected SQL' do
+      expect(
+        described_class.hypertable_detailed_size_sql('events')
+      ).to eq("SELECT * FROM hypertable_detailed_size('events');")
+    end
+  end
+
+  describe '.hypertable_index_size_sql' do
+    it 'returns expected SQL' do
+      expect(
+        described_class.hypertable_index_size_sql('second_index')
+      ).to eq("SELECT hypertable_index_size('second_index');")
+    end
+  end
+
+  describe '.chunks_detailed_size_sql' do
+    it 'returns expected SQL' do
+      expect(
+        described_class.chunks_detailed_size_sql('events')
+      ).to eq("SELECT * FROM chunks_detailed_size('events');")
+    end
+  end
+end


### PR DESCRIPTION
Introduces hypertable functions to Timescaledb::Database
  * hypertable_size_sql
  * hypertable_detailed_size_sql
  * hypertable_index_size_sql
  * chunks_detailed_size_sql

Introduces chunk functions to Timescaledb::Database
  * compress_chunk_sql
  * decompress_chunk_sql