### PR TITLE
reset logger to original after `MigrationHelpers#create_hypertable`

### DIFF
--- a/lib/timescaledb/migration_helpers.rb
+++ b/lib/timescaledb/migration_helpers.rb
@@ -41,6 +41,7 @@ module Timescaledb
                           number_partitions: nil,
                           **hypertable_options)
 
+      original_logger = ActiveRecord::Base.logger
       ActiveRecord::Base.logger = Logger.new(STDOUT)
 
       options = ["chunk_time_interval => INTERVAL '#{chunk_time_interval}'"]
@@ -68,6 +69,8 @@ module Timescaledb
       if compression_interval
         execute "SELECT add_compression_policy('#{table_name}', INTERVAL '#{compression_interval}')"
       end
+    ensure
+      ActiveRecord::Base.logger = original_logger if original_logger
     end
 
     # Create a new continuous aggregate


### PR DESCRIPTION
right now all queries executed after the `create_hypertable` will be printed to the STDOUT and sometimes there's a lot of them

this PR fixes behavior by resetting the logger to the original one, so only `execute` statements from `create_hypertable` will be printed to the STDOUT