### PR TITLE
Add capacity to customize WITH clause options in CREATE MATERIALIZED VIEW via create_continuous_aggregate

### DIFF
--- a/lib/timescaledb/migration_helpers.rb
+++ b/lib/timescaledb/migration_helpers.rb
@@ -87,6 +87,7 @@ module Timescaledb
     # @option finalized [Boolean] Override the WITH clause 'timescaledb.finalized'
     #
     # @see https://docs.timescale.com/api/latest/continuous-aggregates/create_materialized_view/
+    # @see https://docs.timescale.com/api/latest/continuous-aggregates/add_continuous_aggregate_policy/
     #
     # @example
     #   create_continuous_aggregate(:activity_counts, query: <<-SQL, refresh_policies: { schedule_interval: "INTERVAL '1 hour'" })

--- a/lib/timescaledb/migration_helpers.rb
+++ b/lib/timescaledb/migration_helpers.rb
@@ -59,11 +59,11 @@ module Timescaledb
 
       if compress_segmentby
         execute <<~SQL
-        ALTER TABLE #{table_name} SET (
-          timescaledb.compress,
-          timescaledb.compress_orderby = '#{compress_orderby}',
-          timescaledb.compress_segmentby = '#{compress_segmentby}'
-        )
+          ALTER TABLE #{table_name} SET (
+            timescaledb.compress,
+            timescaledb.compress_orderby = '#{compress_orderby}',
+            timescaledb.compress_segmentby = '#{compress_segmentby}'
+          )
         SQL
       end
       if compression_interval
@@ -82,8 +82,11 @@ module Timescaledb
     # @option refresh_policies [String] start_offset: INTERVAL or integer
     # @option refresh_policies [String] end_offset: INTERVAL or integer
     # @option refresh_policies [String] schedule_interval: INTERVAL
+    # @option materialized_only [Boolean] Override the WITH clause 'timescaledb.materialized_only'
+    # @option create_group_indexes [Boolean] Override the WITH clause 'timescaledb.create_group_indexes'
+    # @option finalized [Boolean] Override the WITH clause 'timescaledb.finalized'
     #
-    # @see https://docs.timescale.com/api/latest/continuous-aggregates/add_continuous_aggregate_policy/
+    # @see https://docs.timescale.com/api/latest/continuous-aggregates/create_materialized_view/
     #
     # @example
     #   create_continuous_aggregate(:activity_counts, query: <<-SQL, refresh_policies: { schedule_interval: "INTERVAL '1 hour'" })
@@ -97,14 +100,18 @@ module Timescaledb
     def create_continuous_aggregate(table_name, query, **options)
       execute <<~SQL
         CREATE MATERIALIZED VIEW #{table_name}
-        WITH (timescaledb.continuous) AS
+        WITH (
+          timescaledb.continuous
+          #{build_with_clause_option_string(:materialized_only, options)}
+          #{build_with_clause_option_string(:create_group_indexes, options)}
+          #{build_with_clause_option_string(:finalized, options)}
+        ) AS
         #{query.respond_to?(:to_sql) ? query.to_sql : query}
-        WITH #{"NO" unless options[:with_data]} DATA;
+        WITH #{'NO' unless options[:with_data]} DATA;
       SQL
 
       create_continuous_aggregate_policy(table_name, **(options[:refresh_policies] || {}))
     end
-
 
     #  Drop a new continuous aggregate.
     #
@@ -139,6 +146,18 @@ module Timescaledb
 
     def remove_retention_policy(table_name)
       execute "SELECT remove_retention_policy('#{table_name}')"
+    end
+
+    private
+
+    # Build a string for the WITH clause of the CREATE MATERIALIZED VIEW statement.
+    # When the option is omitted, this method returns an empty string, which allows this gem to use the
+    # defaults provided by TimescaleDB.
+    def build_with_clause_option_string(option_key, options)
+      return '' unless options.key?(option_key)
+
+      value = options[option_key] ? 'true' : 'false'
+      ",timescaledb.#{option_key}=#{value}"
     end
   end
 end

--- a/spec/timescaledb/schema_dumper_spec.rb
+++ b/spec/timescaledb/schema_dumper_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Timescaledb::SchemaDumper, database_cleaner_strategy: :truncation
 
   it "dumps a create_continuous_aggregate for a view in the database" do
     con.execute("DROP MATERIALIZED VIEW IF EXISTS event_counts")
-    con.create_continuous_aggregate(:event_counts, query)
+    con.create_continuous_aggregate(:event_counts, query, materialized_only: true, finalized: true)
 
     if defined?(Scenic)
       Scenic.load # Normally this happens in a railtie, but we aren't loading a full rails env here
@@ -62,6 +62,8 @@ RSpec.describe Timescaledb::SchemaDumper, database_cleaner_strategy: :truncation
     dump = dump_output
 
     expect(dump).to include 'create_continuous_aggregate("event_counts"'
+    expect(dump).to include 'materialized_only: true, finalized: true'
+
     expect(dump).not_to include 'create_view "event_counts"' # Verify Scenic ignored this view
     expect(dump).to include 'create_view "searches", sql_definition: <<-SQL' if defined?(Scenic)
 


### PR DESCRIPTION
This PR is to add the capacity to customize the `WITH` clause options in `CREATE MATERIALIZED VIEW` via `create_continuous_aggregate`. The options are  `materialized_only`, `finalized` and `create_group_indexes`.
Note: In the proposed implementation, if those options are not specified, the defaults from TimescaleDB extension will be used (the defaults have changed between versions).
This PR also add handling of `materialized_only` and `finalized` in the schema dumper. Unfortunately, `create_group_indexes` is not handled since there is no safe way to obtain this information (if there is one, please let me know!).