### PR TITLE
Add hypertable as a valid table definition

### DIFF
--- a/lib/timescaledb/migration_helpers.rb
+++ b/lib/timescaledb/migration_helpers.rb
@@ -29,6 +29,11 @@ module Timescaledb
       create_hypertable(table_name, **options[:hypertable]) if options.key?(:hypertable)
     end
 
+    # Override the valid_table_definition_options to include hypertable.
+    def valid_table_definition_options # :nodoc:
+      super + [:hypertable]
+    end
+
     # Setup hypertable from options
     # @see create_table with the hypertable options.
     def create_hypertable(table_name,


### PR DESCRIPTION
During the migration definition, now in latest Rails, I see some error saying `hypertable` is not a valid keyword for the `create_table` method. I just found the method that is necessary to patch it.