### PR TITLE
Skip schema dumper when extension is not available

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -9,7 +9,9 @@ def uri_from_test
   ENV['PG_URI_TEST']
 end
 
-ActiveRecord::Base.establish_connection(ARGV[0] || uri_from_test)
+uri = ARGV[0] || uri_from_test
+ActiveRecord::Base.establish_connection(uri)
+Timescaledb.establish_connection(uri)
 
 Timescaledb::Hypertable.find_each do |hypertable|
   class_name = hypertable.hypertable_name.singularize.camelize

--- a/lib/timescaledb.rb
+++ b/lib/timescaledb.rb
@@ -17,10 +17,19 @@ require_relative 'timescaledb/schema_dumper'
 require_relative 'timescaledb/stats'
 require_relative 'timescaledb/stats_report'
 require_relative 'timescaledb/migration_helpers'
+require_relative 'timescaledb/extension'
 require_relative 'timescaledb/version'
 
 module Timescaledb
   module_function
+
+  def connection
+    Connection.instance
+  end
+
+  def extension
+    Extension
+  end
 
   def chunks
     Chunk.all

--- a/lib/timescaledb/connection.rb
+++ b/lib/timescaledb/connection.rb
@@ -1,6 +1,11 @@
 require 'singleton'
 
 module Timescaledb
+  # Minimal connection setup for Timescaledb directly with the PG.
+  # The concept is use a singleton component that can query
+  # independently of the ActiveRecord::Base connections.
+  # This is useful for the extension and hypertable metadata.
+  # It can also #use_connection from active record if needed.
   class Connection
     include Singleton
 
@@ -32,6 +37,12 @@ module Timescaledb
     # @param [Boolean] True if the connection singleton was configured, otherwise returns false.
     def connected?
       !@config.nil?
+    end
+
+    # Override the connection with a raw PG connection.
+    # @param [PG::Connection] connection The raw PG connection.
+    def use_connection connection
+      @connection = connection
     end
 
     private

--- a/lib/timescaledb/connection_handling.rb
+++ b/lib/timescaledb/connection_handling.rb
@@ -1,16 +1,21 @@
 module Timescaledb
   class ConnectionNotEstablishedError < StandardError; end
 
-  # @param [String] config The postgres connection string.
+  module_function
+  
+  # @param [String] config with the postgres connection string.
   def establish_connection(config)
     Connection.instance.config = config
   end
-  module_function :establish_connection
+
+  # @param [PG::Connection] to use it directly from a raw connection
+  def use_connection conn
+    Connection.instance.use_connection conn
+  end
 
   def connection
     raise ConnectionNotEstablishedError.new unless Connection.instance.connected?
 
     Connection.instance
   end
-  module_function :connection
 end

--- a/lib/timescaledb/extension.rb
+++ b/lib/timescaledb/extension.rb
@@ -1,0 +1,23 @@
+module Timescaledb
+
+  # Provides metadata around the extension in the database
+  module Extension
+    module_function
+    # @return String version of the timescaledb extension
+    def version
+      @version ||= Timescaledb.connection.query_first(<<~SQL)&.version
+        SELECT extversion as version
+        FROM pg_extension
+        WHERE extname = 'timescaledb'
+      SQL
+    end
+
+    def installed?
+      version.present?
+    end
+
+    def update!
+      Timescaledb.connection.execute('ALTER EXTENSION timescaledb UPDATE')
+    end
+  end
+end

--- a/spec/timescaledb/connection_spec.rb
+++ b/spec/timescaledb/connection_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe Timescaledb do
+  describe '.establish_connection' do
+    it 'returns a PG::Connection object' do
+      expect do
+         Timescaledb.establish_connection(ENV['PG_URI_TEST'])
+      end.to_not raise_error
+    end
+  end
+
+  describe ::Timescaledb::Connection do
+    subject(:connection) { Timescaledb::Connection.instance }
+
+    it 'returns a Connection object' do
+      is_expected.to be_a(Timescaledb::Connection)
+    end
+
+    it 'has fast access to the connection' do
+      expect(connection.send(:connection)).to be_a(PG::Connection)
+    end
+
+    describe '#connected?' do
+      it {  expect(connection.connected?).to be_truthy }
+    end
+
+    describe '#query_first' do
+      let(:sql) { "select 1 as one" }
+      subject(:result) { connection.query_first(sql) }
+
+      it { expect(result).to be_a(OpenStruct) }
+    end
+
+    describe '#query' do
+      let(:sql) { "select 1 as one" }
+      subject(:result) { connection.query(sql) }
+
+      it { expect(result).to eq([OpenStruct.new({"one" => "1"})]) }
+    end
+  end
+end

--- a/spec/timescaledb_spec.rb
+++ b/spec/timescaledb_spec.rb
@@ -3,6 +3,16 @@ RSpec.describe Timescaledb do
     expect(Timescaledb::VERSION).not_to be nil
   end
 
+  describe ".extension" do
+    describe ".installed?" do
+      it { expect(Timescaledb.extension.installed?).to be_truthy }
+    end
+
+    describe ".version" do
+      it { expect(Timescaledb.extension.version).not_to be_empty }
+    end
+  end
+
   describe ".chunks" do
     subject { Timescaledb.chunks }
 


### PR DESCRIPTION
It closes #56 with auto-detecting if the extension is available or not.
