### PR TITLE
Fix schema dump for hypertables partitioned with integer chunk time interval

### DIFF
--- a/lib/timescaledb/migration_helpers.rb
+++ b/lib/timescaledb/migration_helpers.rb
@@ -49,7 +49,7 @@ module Timescaledb
       original_logger = ActiveRecord::Base.logger
       ActiveRecord::Base.logger = Logger.new(STDOUT)
 
-      options = ["chunk_time_interval => INTERVAL '#{chunk_time_interval}'"]
+      options = ["chunk_time_interval => #{chunk_time_interval_clause(chunk_time_interval)}"]
       options += hypertable_options.map { |k, v| "#{k} => #{quote(v)}" }
 
       arguments = [
@@ -164,6 +164,14 @@ module Timescaledb
 
       value = options[option_key] ? 'true' : 'false'
       ",timescaledb.#{option_key}=#{value}"
+    end
+
+    def chunk_time_interval_clause(chunk_time_interval)
+      if chunk_time_interval.is_a?(Numeric)
+        chunk_time_interval
+      else
+        "INTERVAL '#{chunk_time_interval}'"
+      end
     end
   end
 end

--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -78,7 +78,7 @@ module Timescaledb
 
       options = {
         time_column: time.column_name,
-        chunk_time_interval: time.time_interval.inspect,
+        chunk_time_interval: time.time_interval ? time.time_interval.inspect : time.integer_interval,
         **timescale_compression_settings_for(hypertable),
         **timescale_space_partition_for(hypertable),
         **timescale_index_options_for(hypertable)

--- a/spec/support/active_record/schema.rb
+++ b/spec/support/active_record/schema.rb
@@ -39,6 +39,11 @@ def setup_tables
       options: { time_column: 'timestamp' }
     )
 
+    create_table(:hypertable_with_id_partitioning, hypertable: {
+      time_column: 'id',
+      chunk_time_interval: 1_000_000
+    })
+
     create_table(:non_hypertables) do |t|
       t.string :name
     end

--- a/spec/timescaledb/schema_dumper_spec.rb
+++ b/spec/timescaledb/schema_dumper_spec.rb
@@ -123,6 +123,17 @@ RSpec.describe Timescaledb::SchemaDumper, database_cleaner_strategy: :truncation
       expect(dump).to include "create_default_indexes: false"
     end
 
+    it "extracts integer chunk_time_interval" do
+      options = { time_column: :id, chunk_time_interval: 10000 }
+      con.create_table :schema_tests, hypertable: options do |t|
+        t.timestamps
+      end
+
+      dump = dump_output
+
+      expect(dump).to include "chunk_time_interval: 10000"
+    end
+
     context "compress_segmentby" do
       before(:each) do
         con.drop_table :segmentby_tests, force: :cascade if con.table_exists?(:segmentby_tests)


### PR DESCRIPTION
This PR fixes hypertable creation and schema dumping when an integer chunk time interval is used.

Previously it would dump the chunk_time_interval option as `chunk_time_interval: "nil"`.