### PR TITLE
Fix schema dump of continuous aggregate when no refresh policies are defined

### DIFF
--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -159,14 +159,14 @@ module Timescaledb
           interval = timescale_interval(refresh_policy.schedule_interval)
           end_offset = timescale_interval(refresh_policy.config["end_offset"])
           start_offset = timescale_interval(refresh_policy.config["start_offset"])
-          %(refresh_policies: { start_offset: "#{start_offset}", end_offset: "#{end_offset}", schedule_interval: "#{interval}"})
+          %(refresh_policies: { start_offset: "#{start_offset}", end_offset: "#{end_offset}", schedule_interval: "#{interval}"}, )
         else
           ""
         end
 
         with_clause_opts = "materialized_only: #{aggregate[:materialized_only]}, finalized: #{aggregate[:finalized]}"
         stream.puts <<~AGG.indent(2)
-          create_continuous_aggregate("#{aggregate.view_name}", <<-SQL, #{refresh_policies_opts}, #{with_clause_opts})
+          create_continuous_aggregate("#{aggregate.view_name}", <<-SQL, #{refresh_policies_opts}#{with_clause_opts})
             #{aggregate.view_definition.strip.gsub(/;$/, '')}
           SQL
         AGG

--- a/spec/timescaledb/schema_dumper_spec.rb
+++ b/spec/timescaledb/schema_dumper_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe Timescaledb::SchemaDumper, database_cleaner_strategy: :truncation
     expect(dump).to include 'create_continuous_aggregate("event_counts"'
     expect(dump).to include 'materialized_only: true, finalized: true'
 
+    expect(dump).not_to include ', ,'
     expect(dump).not_to include 'create_view "event_counts"' # Verify Scenic ignored this view
     expect(dump).to include 'create_view "searches", sql_definition: <<-SQL' if defined?(Scenic)
 


### PR DESCRIPTION
This PR fixes dumping of continuous aggregate definitions when no refresh policies are defined.

Previously it would leave an empty parameter, which is of course a syntax error:

```ruby
create_continuous_aggregate("aggregate_name", <<-SQL, , materialized_only: false, finalized: true)
```