### PR TITLE
Sort continuous aggregates when dumping to the schema

### DIFF
--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -154,7 +154,7 @@ module Timescaledb
     def timescale_continuous_aggregates(stream)
       return unless Timescaledb::ContinuousAggregates.table_exists?
 
-      Timescaledb::ContinuousAggregates.all.find_each do |aggregate|
+      Timescaledb::ContinuousAggregates.order(:view_name).find_each do |aggregate|
         refresh_policies_opts = if (refresh_policy = aggregate.jobs.refresh_continuous_aggregate.first)
           interval = timescale_interval(refresh_policy.schedule_interval)
           end_offset = timescale_interval(refresh_policy.config["end_offset"])


### PR DESCRIPTION
Makes the schema dumper output consistent by sorting the continuous aggregates by the view name, otherwise the schema can get a random diff depending on the rows order returned by the DB.

```ruby
> Timescaledb::ContinuousAggregates.order(:view_name).pluck(:view_name)
  Timescaledb::ContinuousAggregate Pluck (5.9ms)  SELECT "timescaledb_information"."continuous_aggregates"."view_name" FROM "timescaledb_information"."continuous_aggregates" ORDER BY "timescaledb_information"."continuous_aggregates"."view_name" ASC
```

The hypertables (and the retention policies which are based on them) are already sorted and create a consistent schema output.