### PR TITLE
Make sure views are included in the hierarchical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ You may isolate your hypertables in another database, so, creating an abstract
 layer for your hypertables is a good idea:
 
 ```ruby
-class TimescaledbModel < ActiveRecord::Base
+class Hypertable < ActiveRecord::Base
   self.abstract_class = true
 
   extend Timescaledb::ActsAsHypertable
@@ -352,7 +352,19 @@ end
 And then, you can inherit from this model:
 
 ```ruby
-class Event < TimescaledbModel
+class Event < Hypertable
+  acts_as_hypertable time_column: "time"
+end
+```
+
+Or you can include only when you're going to use them:
+
+```ruby
+class Event < ActiveRecord::Base
+  extend Timescaledb::ActsAsHypertable
+
+  establish_connection :timescaledb
+
   acts_as_hypertable time_column: "time"
 end
 ```

--- a/README.md
+++ b/README.md
@@ -319,6 +319,12 @@ which will correctly handle schema dumping.
 
 ### Enable ActsAsHypertable
 
+Create your `config/initializers/timescaledb.rb` file and add the following line:
+
+```ruby
+ActiveRecord::Base.extend Timescaledb::ActsAsHypertable
+```
+
 You can declare a Rails model as a Hypertable by invoking the `acts_as_hypertable` macro. This macro extends your existing model with timescaledb-related functionality.
 model:
 
@@ -329,6 +335,27 @@ end
 ```
 
 By default, ActsAsHypertable assumes a record's _time_column_ is called `created_at`.
+
+You may isolate your hypertables in another database, so, creating an abstract
+layer for your hypertables is a good idea:
+
+```ruby
+class TimescaledbModel < ActiveRecord::Base
+  self.abstract_class = true
+
+  extend Timescaledb::ActsAsHypertable
+
+  establish_connection :timescaledb
+end
+```
+
+And then, you can inherit from this model:
+
+```ruby
+class Event < TimescaledbModel
+  acts_as_hypertable time_column: "time"
+end
+```
 
 ### Options
 
@@ -435,6 +462,7 @@ define in `spec/rspec_helper.rb`:
 
 ```ruby
 config.before(:suite) do
+
   hypertable_models = ActiveRecord::Base.descendants.select(&:acts_as_hypertable?)
 
   hypertable_models.each do |klass|

--- a/lib/timescaledb/acts_as_hypertable.rb
+++ b/lib/timescaledb/acts_as_hypertable.rb
@@ -62,4 +62,3 @@ module Timescaledb
   end
 end
 
-ActiveRecord::Base.extend Timescaledb::ActsAsHypertable

--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -154,7 +154,7 @@ module Timescaledb
     def timescale_continuous_aggregates(stream)
       return unless Timescaledb::ContinuousAggregates.table_exists?
 
-      Timescaledb::ContinuousAggregates.all.find_each do |aggregate|
+      Timescaledb::ContinuousAggregates.hierarchical.each do |aggregate|
         refresh_policies_opts = if (refresh_policy = aggregate.jobs.refresh_continuous_aggregate.first)
           interval = timescale_interval(refresh_policy.schedule_interval)
           end_offset = timescale_interval(refresh_policy.config["end_offset"])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,9 @@ require "database_cleaner/active_record"
 require_relative "support/active_record/models"
 require_relative "support/active_record/schema"
 
-Dotenv.load!
+Dotenv.load! if File.exists?(".env")
+
+# Establish a connection for testing
 
 ActiveRecord::Base.establish_connection(ENV['PG_URI_TEST'])
 Timescaledb.establish_connection(ENV['PG_URI_TEST'])

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -1,3 +1,5 @@
+ActiveRecord::Base.extend Timescaledb::ActsAsHypertable
+
 class Event < ActiveRecord::Base
   self.primary_key = "identifier"
 

--- a/spec/timescaledb/schema_dumper_spec.rb
+++ b/spec/timescaledb/schema_dumper_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Timescaledb::SchemaDumper, database_cleaner_strategy: :truncation
     Event
       .from("event_counts")
       .select("time_bucket('1d', time) as time,
-              identifier as label,
-              sum(value) as value").group("1,2")
+              sum(value) as value").group("1")
   end
 
   context "schema" do
@@ -78,6 +77,7 @@ RSpec.describe Timescaledb::SchemaDumper, database_cleaner_strategy: :truncation
   end
 
   it "dumps a create_continuous_aggregate for a view in the database" do
+    con.execute("DROP MATERIALIZED VIEW IF EXISTS event_daily_counts")
     con.execute("DROP MATERIALIZED VIEW IF EXISTS event_counts")
     con.create_continuous_aggregate(:event_counts, query, materialized_only: true, finalized: true)
     con.create_continuous_aggregate(:event_daily_counts, query_daily, materialized_only: true, finalized: true)


### PR DESCRIPTION
It fixes #71 and #70.

I also removed the defaults of Timescaledb being included as a function. So, folks should be adding it to the class level they want and the library will not pollute the `ActiveRecord::Base`.

If you got an error like `undefined method acts_as_hypertable for ActiveRecord::Base`. You should include it on your side, making it available via `config/initializers/timescaledb.rb` on your rails app or just make a new class to inherit your hypertable classes.

```ruby
ActiveRecord::Base.extend Timescaledb::ActsAsHypertable
```

