### PR TITLE
Aggregate association fix for Timescale >=0.20

### DIFF
--- a/lib/timescaledb/continuous_aggregates.rb
+++ b/lib/timescaledb/continuous_aggregates.rb
@@ -3,10 +3,10 @@ module Timescaledb
     self.table_name = "timescaledb_information.continuous_aggregates"
     self.primary_key = 'materialization_hypertable_name'
 
-    has_many :jobs, foreign_key: "hypertable_name", primary_key: "hypertable_name",
+    has_many :jobs, foreign_key: "hypertable_name", primary_key: "view_name",
       class_name: "Timescaledb::Job"
 
-    has_many :chunks, foreign_key: "hypertable_name", primary_key: "hypertable_name",
+    has_many :chunks, foreign_key: "hypertable_name",
       class_name: "Timescaledb::Chunk"
 
     scope :resume, -> do

--- a/lib/timescaledb/continuous_aggregates.rb
+++ b/lib/timescaledb/continuous_aggregates.rb
@@ -3,10 +3,10 @@ module Timescaledb
     self.table_name = "timescaledb_information.continuous_aggregates"
     self.primary_key = 'materialization_hypertable_name'
 
-    has_many :jobs, foreign_key: "hypertable_name",
+    has_many :jobs, foreign_key: "hypertable_name", primary_key: "hypertable_name",
       class_name: "Timescaledb::Job"
 
-    has_many :chunks, foreign_key: "hypertable_name",
+    has_many :chunks, foreign_key: "hypertable_name", primary_key: "hypertable_name",
       class_name: "Timescaledb::Chunk"
 
     scope :resume, -> do


### PR DESCRIPTION
Fixes https://github.com/timescale/timescaledb-ruby/issues/119, speculatively

This will fail on versions < 0.20. @jonatas any idea how to solve that problem? timescale >= 0.20 seems to be using a different metadata format than previous versions, so we may have to switch the approach based on extension version used.